### PR TITLE
removed removePseudoIdField

### DIFF
--- a/src/__tests__/fieldConverter-test.js
+++ b/src/__tests__/fieldConverter-test.js
@@ -170,7 +170,6 @@ describe('fieldConverter', () => {
       const embeddedFields = embeddedType._typeConfig.fields();
       expect(embeddedFields.email).to.be.ok;
       expect(embeddedFields.locationId).to.be.ok;
-      expect(embeddedFields._id).to.be.undefined;
     });
 
     it('should return null if subdocument is empty', async () => {
@@ -251,7 +250,6 @@ describe('fieldConverter', () => {
 
   describe('documentArrayToGraphQL()', () => {
     const languagesType = documentArrayToGraphQL(fields.languages);
-    const languagesFields = languagesType.ofType._typeConfig.fields();
 
     it('should produce GraphQLList', () => {
       expect(languagesType).to.be.instanceof(GraphQLList);
@@ -260,10 +258,6 @@ describe('fieldConverter', () => {
     it('should has Language type in ofType', () => {
       // see src/__mocks__/languageSchema.js where type name `Language` is defined
       expect(languagesType.ofType.name).to.equal('Language');
-    });
-
-    it('should skip pseudo mongoose _id field in document', () => {
-      expect(languagesFields._id).to.be.undefined;
     });
   });
 

--- a/src/__tests__/fieldConverter-test.js
+++ b/src/__tests__/fieldConverter-test.js
@@ -170,6 +170,7 @@ describe('fieldConverter', () => {
       const embeddedFields = embeddedType._typeConfig.fields();
       expect(embeddedFields.email).to.be.ok;
       expect(embeddedFields.locationId).to.be.ok;
+      expect(embeddedFields._id).to.be.ok;
     });
 
     it('should return null if subdocument is empty', async () => {
@@ -250,6 +251,7 @@ describe('fieldConverter', () => {
 
   describe('documentArrayToGraphQL()', () => {
     const languagesType = documentArrayToGraphQL(fields.languages);
+    const languagesFields = languagesType.ofType._typeConfig.fields();
 
     it('should produce GraphQLList', () => {
       expect(languagesType).to.be.instanceof(GraphQLList);
@@ -258,6 +260,10 @@ describe('fieldConverter', () => {
     it('should has Language type in ofType', () => {
       // see src/__mocks__/languageSchema.js where type name `Language` is defined
       expect(languagesType.ofType.name).to.equal('Language');
+    });
+
+    it('should include pseudo mongoose _id field in document', () => {
+      expect(languagesFields._id).to.be.ok;
     });
   });
 

--- a/src/fieldsConverter.js
+++ b/src/fieldsConverter.js
@@ -248,17 +248,6 @@ export function deriveComplexType(field: MongooseFieldT): ComplexTypesT {
   return ComplexTypes.SCALAR;
 }
 
-function removePseudoIdField(typeComposer: TypeComposer): void {
-  // remove pseudo object id mongoose field
-  const gqFields = typeComposer.getFields();
-  const pseudoFieldNames = ['_id'];
-  pseudoFieldNames.forEach((name) => {
-    if (gqFields[name] && gqFields[name].type === GraphQLMongoID) {
-      typeComposer.removeField(name);
-    }
-  });
-}
-
 export function scalarToGraphQL(field: MongooseFieldT): GraphQLOutputType {
   const typeName = _getFieldType(field);
 
@@ -304,11 +293,9 @@ export function embeddedToGraphQL(
 
   const typeName = `${prefix}${capitalize(fieldName)}`;
   const typeComposer = convertSchemaToGraphQL(field.schema, typeName);
-  removePseudoIdField(typeComposer);
 
   return typeComposer.getType();
 }
-
 
 export function enumToGraphQL(
   field: MongooseFieldT,
@@ -349,7 +336,6 @@ export function documentArrayToGraphQL(
   const typeName = `${prefix}${capitalize(_getFieldName(field))}`;
 
   const typeComposer = convertModelToGraphQL(field, typeName);
-  removePseudoIdField(typeComposer);
 
   return new GraphQLList(typeComposer.getType());
 }


### PR DESCRIPTION
Removed the function that strips `_id` from embedded documents.

Please see #19 for more info.