### PR TITLE
fix: Support builtin js objects in dotted notation

### DIFF
--- a/src/utils/__tests__/toMongoDottedObject-test.js
+++ b/src/utils/__tests__/toMongoDottedObject-test.js
@@ -28,4 +28,16 @@ describe('toMongoDottedObject()', () => {
       'a.b': 3,
     });
   });
+
+  it('should handle date object values as scalars', () => {
+    expect(toMongoDottedObject({ dateField: new Date(100) })).toEqual({
+      dateField: new Date(100),
+    });
+  });
+
+  it('should handle date object values when nested', () => {
+    expect(toMongoDottedObject({ a: { dateField: new Date(100) } })).toEqual({
+      'a.dateField': new Date(100),
+    });
+  });
 });

--- a/src/utils/toMongoDottedObject.js
+++ b/src/utils/toMongoDottedObject.js
@@ -19,8 +19,10 @@ export default function toMongoDottedObject(
   target?: Object = {},
   path?: string[] = []
 ): { [dottedPath: string]: mixed } {
+  const objKeys = Object.keys(obj);
+
   /* eslint-disable */
-   Object.keys(obj).forEach(key => {
+  objKeys.forEach(key => {
      if (key.startsWith('$')) {
        target[path.join('.')] = { 
          ...target[path.join('.')],
@@ -32,6 +34,11 @@ export default function toMongoDottedObject(
        target[path.concat(key).join('.')] = obj[key];
      }
    });
+
+   if (objKeys.length === 0) {
+     target[path.join('.')] = obj;
+   }
+   
    return target;
    /* eslint-enable */
 }


### PR DESCRIPTION
Converting a dotted notation shouldn't  try and nest keys of builtin objects

I have noticed when trying to use date fields in generated "filter" args they are ignored.
I suspect the problem is the conversion to dotted notation.
This PR adds tests that show the problem and a fix which may be naive but was reasonable to me.