### PR TITLE
Do not call mongoose for findByIds with empty array argument

### DIFF
--- a/src/resolvers/findByIds.js
+++ b/src/resolvers/findByIds.js
@@ -46,7 +46,7 @@ export default function findByIds(
     resolve: (resolveParams: ExtendedResolveParams) => {
       const args = resolveParams.args || {};
 
-      if (!Array.isArray(args._ids)) {
+      if (!Array.isArray(args._ids) || args._ids.length === 0) {
         return Promise.resolve([]);
       }
 


### PR DESCRIPTION
As discussed in #74 

- There is already a test passing an empty array, so this should be ok
- `Array.isArray` returns false for null / undefined, therefore no additional null check should be needed